### PR TITLE
Added basic support for Windows and a simple progress indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ You can also use this option multiple times to check multiple products at once.
 
 See the [`local_cache_path`](#config_local_cache_path) configuration option to override the default location these are stored.
 
+Use the `--platform win` option with the `--product-plist` option to fetch the latest Adobe updates for Windows products (as .zip files) using the these channels, defaults to "mac"
+
+Note: Munki isn't designed to understand Windows based Adobe updates so the `--platform win` option cannot be used with the --munkiimport option
+
 
 ### Importing into Munki
 
@@ -37,9 +41,11 @@ Some organizations can't use `munkiimport` and need to use `makepkginfo` instead
 
 ### Generating product plists
 
-The `--build-product-plist` option will generate a product plist automatically, using all Channel IDs found at the path of an Adobe ESD installer:
+The `--build-product-plist` option will generate a product plist automatically, using all Channel IDs found at the path of an Adobe ESD installer or a .ccp file from a (Mac or Windows) installer built using Creative Cloud Packager:
 
 `./aamporter.py --build-product-plist "/Volumes/CS6 DesWebPrm"`
+
+`./aamporter.py --build-product-plist "AdobeCCPhotoshopInstaller.ccp"`
 
 This will save a plist named after the location given, but you can name it anything you'd like. You may want to modify it to include only the updates you're interested in for the product. Most suites have roughly a dozen "base product" channels that will get updates for themselves and shared components like Dynamic Link Media Server and CSXS Infrastructure. For example, we could reduce this list down to something like:
 

--- a/aamporter.py
+++ b/aamporter.py
@@ -635,11 +635,10 @@ save a product plist containing every Channel ID found for the product. Plist is
                                 we_have_bytes, bytes))
                     if need_to_dl:
                         L.log(INFO, "Downloading %s %s (%s bytes) to %s" % (update.product, update.version, bytes, output_filename))
-                        
                         if opts.no_progressbar:
-                            reporthook = None
-                        
-                        urllib.urlretrieve(dmg_url, output_filename, reporthook)
+                            urllib.urlretrieve(dmg_url, output_filename)
+                        else:
+                            urllib.urlretrieve(dmg_url, output_filename, reporthook)
                         
     L.log(INFO, "Done caching updates.")
 

--- a/aamporter.py
+++ b/aamporter.py
@@ -472,6 +472,8 @@ save a product plist containing every Channel ID found for the product. Plist is
         errorExit("--munki-update-for requires the --build-product-plist option!")
     if not opts.build_product_plist and not opts.product_plist:
         errorExit("One of --product-plist or --build-product-plist must be specified!")
+    if opts.platform == 'win' and opts.munkiimport:
+        errorExit("Cannot use the --munkiimport option with --platform win option!")
 
     if opts.build_product_plist:
         esd_path = opts.build_product_plist


### PR DESCRIPTION
Hey Tim - This adds the ability to download updates from the Windows feed and also parse a Windows .ccp file. I'm thinking that maybe using the --platform win option should also disable any attempt to use munkiimport or if that would be assumed. Thoughts?