### PR TITLE
Correct logic for --catalog feature

### DIFF
--- a/aamporter.py
+++ b/aamporter.py
@@ -741,7 +741,7 @@ save a product plist containing every Channel ID found for the product. Plist is
                     munkiimport_opts.append(version_meta['display_name'])
                     munkiimport_opts.append('--description')
                     munkiimport_opts.append(version_meta['description'])
-                    if '--catalog' not in munkiimport_opts:
+                    if not any("--catalog" in s for s in munkiimport_opts)::
                         munkiimport_opts.append('--catalog')
                         munkiimport_opts.append('testing')
 

--- a/aamporter.py
+++ b/aamporter.py
@@ -741,9 +741,6 @@ save a product plist containing every Channel ID found for the product. Plist is
                     munkiimport_opts.append(version_meta['display_name'])
                     munkiimport_opts.append('--description')
                     munkiimport_opts.append(version_meta['description'])
-                    if not any("--catalog" in s for s in munkiimport_opts)::
-                        munkiimport_opts.append('--catalog')
-                        munkiimport_opts.append('testing')
 
                     if 'makepkginfo_options' in version_meta:
                         L.log(VERBOSE,


### PR DESCRIPTION
Currently it is searching for a string inside of a list, the results is the "testing" catalog is added on every run even if we manually assign the catalog. 